### PR TITLE
support YAML front matter, use title if available

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -127,5 +127,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  yaml:
+    dependency: "direct main"
+    description:
+      name: yaml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,6 @@ dependencies:
   path: any
   shelf: any
   shelf_static: any
+  yaml: ^3.1.0
 executables:
   markymark:


### PR DESCRIPTION
At the risk of adding too much complexity to this very elegant little package, I've added support for the only thing that was missing for me which was support for handling YAML front matter in the markdown, as I use that on my static gen  website.

So this PR adds handling of YAML front matter in the markdown, and as a bonus, if present use its title field.